### PR TITLE
fix leak

### DIFF
--- a/src/qsbr.c
+++ b/src/qsbr.c
@@ -75,6 +75,15 @@ qsbr_create(void)
 }
 
 void
+qsbr_unregister(qsbr_t *qs)
+{
+	qsbr_tls_t *t = pthread_getspecific(qs->tls_key);
+
+	free(t);
+	pthread_setspecific(qs->tls_key, NULL);
+}
+
+void
 qsbr_destroy(qsbr_t *qs)
 {
 	pthread_key_delete(qs->tls_key);

--- a/src/qsbr.h
+++ b/src/qsbr.h
@@ -20,6 +20,7 @@ __BEGIN_DECLS
 qsbr_t *	qsbr_create(void);
 void		qsbr_destroy(qsbr_t *);
 
+void		qsbr_unregister(qsbr_t *);
 int		qsbr_register(qsbr_t *);
 void		qsbr_checkpoint(qsbr_t *);
 qsbr_epoch_t	qsbr_barrier(qsbr_t *);


### PR DESCRIPTION
as pthread_getspecific can return an allocated object(in qsbr_register),
but is never free.
I free 't' in qsbr_destroy, I guess 't' won't be use past qsbr_destroy.

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>