### PR TITLE
ebr_unregister: Add new function ebr_unregister.

### DIFF
--- a/src/ebr.c
+++ b/src/ebr.c
@@ -74,6 +74,14 @@ ebr_create(void)
 }
 
 void
+ebr_unregister(ebr_t *ebr)
+{
+	ebr_tls_t *t = pthread_getspecific(ebr->tls_key);
+	pthread_setspecific(ebr->tls_key, NULL);
+	free(t);
+}
+
+void
 ebr_destroy(ebr_t *ebr)
 {
 	pthread_key_delete(ebr->tls_key);

--- a/src/ebr.h
+++ b/src/ebr.h
@@ -18,6 +18,7 @@ typedef struct ebr ebr_t;
 ebr_t *		ebr_create(void);
 void		ebr_destroy(ebr_t *);
 int		ebr_register(ebr_t *);
+void		ebr_unregister(ebr_t *);
 
 void		ebr_enter(ebr_t *);
 void		ebr_exit(ebr_t *);


### PR DESCRIPTION
I added ebr_unregister because we were using his counterpart to fix a leak for outscale